### PR TITLE
Fix NaCl build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - if [ $TARGET_PLATFORM == Mac ]; then git -C src/third_party clone https://chromium.googlesource.com/chromium/tools/depot_tools.git; fi
   - if [ $TARGET_PLATFORM == Mac ]; then export PATH="$PATH":`pwd`/src/third_party/depot_tools; fi
   - if [ $TARGET_PLATFORM == Mac ]; then brew update && brew install qt5; fi
-  - if [ $TARGET_PLATFORM == NaCl ]; then cd src/third_party && curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip && cd nacl_sdk && ./naclsdk install pepper_49 && cd ../../../; fi
+  - if [ $TARGET_PLATFORM == NaCl ]; then cd src/third_party && curl -LO https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip && cd nacl_sdk/sdk_cache && curl -LO https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/naclsdk_manifest2.json && cd ../ && sed -i '/ca_certs/d' sdk_tools/download.py && ./naclsdk install pepper_49 && cd ../../../; fi
   - if [ ${TARGET_PLATFORM:0:7} == Android ]; then jdk_switcher use openjdk7; fi
   - if [ ${TARGET_PLATFORM:0:7} == Android ]; then cd src/third_party && curl -LO http://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip && unzip -q android-ndk-r16b-linux-x86_64.zip && rm android-ndk-r16b-linux-x86_64.zip && curl -L http://dl.google.com/android/android-sdk_r24.1.2-linux.tgz | tar -zx && cd ../../; fi
   - if [ ${TARGET_PLATFORM:0:7} == Android ]; then export ANDROID_NDK_HOME=`pwd`/src/third_party/android-ndk-r16b ; fi

--- a/docker/fedora23/Dockerfile
+++ b/docker/fedora23/Dockerfile
@@ -49,7 +49,9 @@ RUN mkdir -p /home/mozc_builder/work
 WORKDIR /home/mozc_builder/work
 
 ## NaCl SDK
-RUN curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip
+RUN curl -LO https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip
+RUN cd nacl_sdk/sdk_cache && curl -LO https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/naclsdk_manifest2.json
+RUN sed -i '/ca_certs/d' nacl_sdk/sdk_tools/download.py
 RUN cd nacl_sdk && ./naclsdk install pepper_49
 ENV NACL_SDK_ROOT /home/mozc_builder/work/nacl_sdk/pepper_49
 

--- a/docker/ubuntu14.04/Dockerfile
+++ b/docker/ubuntu14.04/Dockerfile
@@ -66,6 +66,8 @@ RUN curl -LO https://dl.google.com/dl/android/repository/support_r23.1.1.zip && 
 
 ## NaCl SDK
 RUN curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip
+RUN cd nacl_sdk/sdk_cache && curl -LO https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/naclsdk_manifest2.json
+RUN sed -i '/ca_certs/d' nacl_sdk/sdk_tools/download.py
 RUN cd nacl_sdk && ./naclsdk install pepper_49
 ENV NACL_SDK_ROOT /home/mozc_builder/work/nacl_sdk/pepper_49
 


### PR DESCRIPTION
証明書エラーによりNaCl SDKのインストールが失敗する問題の修正

* [NACL Python Installation Failure - Google グループ](https://groups.google.com/d/msg/native-client-discuss/ViBofmhWpyM/_liFs73iAQAJ) を参考に`sdk_tools/download.py`の証明書検証をしない様に変更。
* `./naclsdk`実行時にSDK自体のアップデートが実行され前項の修正が無効となるため、Manifestを事前に取得しておきアップデートが実行されない様にDockerfile及びtravis.ymlを修正。